### PR TITLE
Added keyword 'let' to grammar

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -712,7 +712,7 @@
         'name': 'meta.class.instance.constructor'
       }
       {
-        'match': '\\b(boolean|byte|char|class|double|enum|float|function|int|interface|long|short|var|void)\\b'
+        'match': '\\b(boolean|byte|char|class|double|enum|float|function|int|interface|long|short|var|let|void)\\b'
         'name': 'storage.type.js'
       }
       {


### PR DESCRIPTION
This adds the `let` keyword to the grammar, and gives it the same storage type as `var`. Previously, `let` went unrecognized and was treated as a variable name.