### PR TITLE
Adds support for .msx (jsx for mithril).

### DIFF
--- a/grammars/JavaScript with JSX.cson
+++ b/grammars/JavaScript with JSX.cson
@@ -1,6 +1,7 @@
 fileTypes: [
   "js"
   "jsx"
+  "msx"
   "react.js"
 ]
 name: "JavaScript with JSX"


### PR DESCRIPTION
Hi, this plugin works good for Mithril's `.msx` files. So I just added "msx" to file types.