### PR TITLE
[Fixed]: 'default' keyword syntax highlighting

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -720,8 +720,12 @@
         'name': 'storage.modifier.js'
       }
       {
-        'match': '\\b(break|case|catch|continue|default|do|else|finally|for|goto|if|import|from|as|package|return|switch|throw|try|while)\\b'
+        'match': '\\b(break|case|catch|continue|do|else|finally|for|goto|if|import|from|as|package|return|switch|throw|try|while)\\b'
         'name': 'keyword.control.js'
+      }
+      {
+        'match': '\\b(default)\\b'
+        'name': 'keyword.operator.default.js'
       }
       {
         'match': '\\b(delete|in(stanceof)?|new|typeof|void|with)\\b'


### PR DESCRIPTION
removed 'default' from keyword.control.js and added it to it's own scope of keyword.operator.default.js

fixes issue #31 

@subtleGradient 
@kengorab 

Here is a screenshot:

![added-better-syntax-coloring-jsx](https://user-images.githubusercontent.com/5333019/26950063-02480c08-4c62-11e7-95fe-923969dc7431.png)
